### PR TITLE
RSDEV-444: Upgrade rspace-dryad-adapter to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0 2026-04-29
+- Spring 6 / Hibernate 6 / Jakarta namespace migration
+- Switch to rspace-parent 3.0.0
+
 ## 1.0.4
 - switch to latest dryad-java-client (migrated to rspace-parent pom)
 - bump rspace-parent pom 2.1.3->2.1.4

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.20</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>rspace-parent</artifactId>
         <groupId>com.github.rspace-os</groupId>
-        <version>3.0.0</version>
+        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </parent>
 
     <repositories>
@@ -34,12 +34,12 @@
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>dryad-java-client</artifactId>
-            <version>1.0.0</version>
+            <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>rspace-repository-spi</artifactId>
-            <version>2.0.0</version>
+            <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rspace-dryad-adapter</artifactId>
-    <version>1.0.4</version>
+    <version>2.0.0</version>
     <name>RSpace connector to Dryad, based on dryad-java-client</name>
 
     <parent>
         <artifactId>rspace-parent</artifactId>
         <groupId>com.github.rspace-os</groupId>
-        <version>2.1.4</version>
+        <version>3.0.0</version>
     </parent>
 
     <repositories>
@@ -34,12 +34,12 @@
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>dryad-java-client</artifactId>
-            <version>0.2.2</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>rspace-repository-spi</artifactId>
-            <version>1.1.1</version>
+            <version>2.0.0</version>
         </dependency>
 
         <dependency>
@@ -90,15 +90,9 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <version>${servlet.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.servlet</artifactId>
-            <version>3.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <version>2.20</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Upgrade rspace-dryad-adapter to 2.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Pom-only: migrates servlet API to Jakarta, drops the obsolete Glassfish servlet test dependency, and inherits Jackson versions from the parent BOM.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>